### PR TITLE
[AN-17] The Logical operator preserves previous condition.

### DIFF
--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -108,7 +108,9 @@ export function setCurrentConditions(state, condition) {
     if (index === -1) {
         state.currentConditions.push(condition);
     } else {
-        Vue.set(state.currentConditions, index, condition);
+        let conditionFixed = condition;
+        conditionFixed[2] = state.currentConditions[index][2];
+        Vue.set(state.currentConditions, index, conditionFixed);
     }
 }
 


### PR DESCRIPTION
 In Filter modal window every category of filters receives a condition (ANY, ONLY, ALL, NONe). Before upon every update this condition returned to the initial value (ANY). Now every category preserves its condition after updates.