### PR TITLE
[AN-35] Selected variant should not leave the visible area during scrolling by arrows.

### DIFF
--- a/src/components/variantsListPanel/VariantsPanelList.vue
+++ b/src/components/variantsListPanel/VariantsPanelList.vue
@@ -27,6 +27,11 @@ import BaseVariantIcon from './BaseVariantIcon.vue';
 
 export default {
     name: 'VariantList',
+    data() {
+        return {
+            
+        };
+    },
     props: {
         data: Array,
         selectedItem: Number,
@@ -40,6 +45,17 @@ export default {
         if (this.root) {
             this.$store.commit('setListMounting', false);
         }
+    },
+    updated() {
+        const item_element = document.querySelector('.variants-list > .variants-list_item__active');
+        const list_element = document.querySelector('.baron__scroller');
+        if ((!list_element) || (!item_element)) return;
+        const item_rect = item_element.getBoundingClientRect();
+        const list_rect = list_element.getBoundingClientRect();
+        let diff = 0;
+        if (list_rect.top > item_rect.top) diff = item_rect.top - list_rect.top;
+        if (item_rect.bottom > list_rect.bottom) diff = item_rect.bottom - list_rect.bottom;
+        list_element.scrollTop += diff;
     },
 };
 </script>

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -108,7 +108,9 @@ export function setCurrentConditions(state, condition) {
     if (index === -1) {
         state.currentConditions.push(condition);
     } else {
-        Vue.set(state.currentConditions, index, condition);
+        let conditionFixed = condition;
+        conditionFixed[2] = state.currentConditions[index][2];
+        Vue.set(state.currentConditions, index, conditionFixed);
     }
 }
 


### PR DESCRIPTION
Now if you open list of variants and start change selected variant by arrows-keys then you see the selected variant always. If it intends to leave visible area then the site scrolls the list so that the variant becomes visible again.