### PR TITLE
[AN-112] Now the Coordinates filter displays the min and max values correctly.

### DIFF
--- a/src/components/filterModal/statsList/StatsList.vue
+++ b/src/components/filterModal/statsList/StatsList.vue
@@ -158,7 +158,7 @@ export default {
                     return nonCheckedRes && (isSubstat ? item[0].toLowerCase() :
                         item[0].toLowerCase().includes(query));
                 }
-                return false;
+                return true;
             });
         },
         toggleNonzeroCheckbox() {


### PR DESCRIPTION
The filter Start Position of group Coordinates (and other similar filters) didn't show min and max values. Now it works correctly.