### PR TITLE
[AN-154] Renew the list of tags on the filters panel after an adding a new tag.

### DIFF
--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -197,6 +197,7 @@ export function addNewTag(context, newTagTitle) {
             context.commit('setAllTags', allTags);
             context.commit('setSelectedTags', selectedTags);
             context.commit('clearTagFilterValue');
+            getZoneList(context);
         })
         .catch((error) => {
             context.commit('setAllTags', []);


### PR DESCRIPTION
If somebody opens a variant and add a new tag on the tags panel then in the tags dropdown on the filters panel the tag appears.